### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+2.1.0 (2026-01-18)
+------------------
+
+* Add support for Python 3.12, 3.13, and 3.14
+* Add support for Django 6.0
+* Migrate from Poetry to uv for faster dependency management
+* Replace flake8, black, and isort with ruff for unified linting and formatting
+* Add pre-commit configuration for automated code quality checks
+* Update build system to use hatchling
+* Modernize pyproject.toml to PEP 621 standard format
+
 2.0.0 (2026-01-12)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,15 @@ Install uv:
     $ curl -LsSf https://astral.sh/uv/install.sh | sh
     # or
     $ pip install uv
+<<<<<<< HEAD
+=======
+
+Install dependencies:
+
+.. code-block:: shell
+
+    $ uv sync --extra dev
+>>>>>>> f92989a (Update README)
 
 Install dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dataexporter"
-version = "2.0.0"
+version = "2.1.0"
 description = "Extensible helper to export Django QuerySets and other data to CSV and Excel."
 authors = [
 	{name = "Stephan Jaekel", email = "steph@rdev.info"},

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 requires = tox>=4
+<<<<<<< HEAD
 env_list = py{310,311,312,313,314}-django{32,42,52,60}
+=======
+env_list = py{310,311}-django{32,42,52}
+>>>>>>> ad2b4ce (Update tox configuration)
 
 [gh-actions]
 python =


### PR DESCRIPTION
Prepare new release:

* Add support for Python 3.12, 3.13, and 3.14
* Add support for Django 6.0
* Migrate from Poetry to uv for faster dependency management
* Replace flake8, black, and isort with ruff for unified linting and formatting
* Add pre-commit configuration for automated code quality checks
* Update build system to use hatchling
* Modernize pyproject.toml to PEP 621 standard format