### PR TITLE
Release version 2.1.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,14 +15,15 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install uv"
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - name: "Install dependencies"
         run: |
           set -xe
@@ -33,7 +34,7 @@ jobs:
         run: "python -m tox"
 
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v2"
+        uses: "codecov/codecov-action@v5"
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+2.1.0 (2026-01-18)
+------------------
+
+* Add support for Python 3.12, 3.13, and 3.14
+* Add support for Django 6.0
+* Migrate from Poetry to uv for faster dependency management
+* Replace flake8, black, and isort with ruff for unified linting and formatting
+* Add pre-commit configuration for automated code quality checks
+* Update build system to use hatchling
+* Modernize pyproject.toml to PEP 621 standard format
+
 2.0.0 (2026-01-12)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dataexporter"
-version = "2.0.0"
+version = "2.1.0"
 description = "Extensible helper to export Django QuerySets and other data to CSV and Excel."
 authors = [
 	{name = "Stephan Jaekel", email = "steph@rdev.info"},

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "django-dataexporter"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -403,7 +403,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Release version 2.1.0:

* Add support for Python 3.12, 3.13, and 3.14
* Add support for Django 6.0
* Migrate from Poetry to uv for faster dependency management
* Replace flake8, black, and isort with ruff for unified linting and formatting
* Add pre-commit configuration for automated code quality checks
* Update build system to use hatchling
* Modernize pyproject.toml to PEP 621 standard format